### PR TITLE
Fix access to private property `cookies` in `HttpResponse` class

### DIFF
--- a/src/Client/HttpResponse.php
+++ b/src/Client/HttpResponse.php
@@ -71,6 +71,11 @@ class HttpResponse
         return $this->cookies;
     }
 
+    function setCookies($cookies): void
+    {
+        $this->cookies = $cookies;
+    }
+
     function __toString()
     {
         return $this->body();

--- a/src/Client/PendingHttpRequest.php
+++ b/src/Client/PendingHttpRequest.php
@@ -184,7 +184,7 @@ class PendingHttpRequest
                     $this->transferStats = $transferStats;
                 }
             ], $options))), function($response) {
-                $response->cookies = $this->cookies;
+                $response->setCookies($this->cookies);
                 $response->transferStats = $this->transferStats;
             });
         } catch (ConnectException $e) {


### PR DESCRIPTION
## Description

When we call method:

```php
$response = $this->kit->getAccessToken();
```

We get error:

```sh
Cannot access private property Afiqiqmal\HuaweiPush\Client\HttpResponse::$cookies
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
